### PR TITLE
Appears 'View PDF' option in iPad iPhone and iPod

### DIFF
--- a/pdf/static/js/pdf_view.js
+++ b/pdf/static/js/pdf_view.js
@@ -13,5 +13,14 @@ function pdfXBlockInitView(runtime, element) {
             var handlerUrl = runtime.handlerUrl(element, 'on_download');
             $.post(handlerUrl, '{}');
         });
+
+        /*
+         * <object> tag shows only first page in iPad, iPhone and iPod
+         * 'View PDF' option will appear in these devices to view pdf in new tab */
+
+        let isRetinaDevice = /iPad|iPhone|iPod/.test(navigator.userAgent);
+        if (isRetinaDevice) {
+            $('.pdf-view-button').show();
+        }
     });
 }

--- a/pdf/templates/html/pdf_view.html
+++ b/pdf/templates/html/pdf_view.html
@@ -11,6 +11,9 @@
   {% if allow_download or source_url != "" %}
   <ul>
     {% if allow_download %}
+    <li class="pdf-view-button" style="display: none;">
+      <a href="{{ url }}" target="_blank">{% trans "View PDF" %}</a>
+    </li>
     <li class="pdf-download-button">
       <a href="{{ url }}" download>{% trans "Download the PDF" %}</a>
     </li>


### PR DESCRIPTION
<object> tag shows only first page in iPad, iPhone, and iPod
'View PDF' option will appear in these devices to view pdf in new tab